### PR TITLE
Create action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ runs:
 
     - name: Unzip ndk
       if: ${{ !steps.cache.outputs.cache-hit }}
-      run: unzip "${HOME}/ndk.zip" -o "${HOME}/"
+      run: unzip "${HOME}/ndk.zip" -d "${HOME}/"
       shell: bash
 
     - name: Set output

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,35 @@
+name: "Setup canary ndk"
+description: "Sets up canary ndk"
+outputs:
+  ndk-path:
+    value: ${{ steps.path.outputs.path }}
+    description: "Output path of the ndk"
+  cache-hit:
+    value: ${{ steps.cache.outputs.cache-hit }}
+    description: "Whether a cache hit occurred for the ndk"
+runs:
+  using: "composite"
+  steps:
+    - name: NDK cache
+      id: cache
+      uses: actions/cache@v3
+      with:
+        path: ${HOME}/android-ndk-r27-canary/
+        key: ${{ runner.os }}-ndk-r27-canary
+
+    - name: Download canary ndk
+      if: ${{ !steps.cache.outputs.cache-hit }}
+      env:
+        CANARY_URL: https://github.com/QuestPackageManager/ndk-canary-archive/releases/download/27.0.1/android-ndk-10883340-linux-x86_64.zip
+      run: wget ${CANARY_URL} -O ${HOME}/ndk.zip
+      shell: bash
+
+    - name: Unzip ndk
+      if: ${{ !steps.cache.outputs.cache-hit }}
+      run: unzip "${HOME}/ndk.zip" -o "${HOME}/"
+      shell: bash
+
+    - name: Set output
+      id: path
+      shell: bash
+      run: echo "path=${HOME}/android-ndk-r27-canary" >> ${GITHUB_OUTPUT}


### PR DESCRIPTION
This change allows GitHub workflows to use this repository for the action instead of including it in individual repositories, which are currently failing to build due to what appears to be an issue on symbolic links.
```
7-Zip 23.01 (x64) : Copyright (c) 1999-2023 Igor Pavlov : 2023-06-20
 64-bit locale=C.UTF-8 Threads:4 OPEN_MAX:65536

Scanning the drive for archives:
1 file, 730338259 bytes (697 MiB)

Extracting archive: /home/runner/ndk.zip
ERROR: Dangerous symbolic link path was ignored : android-ndk-r27-canary/toolchains/llvm/prebuilt/linux-x86_64/lib/python3.10/site-packages/lldb/_lldb.cpython-310-x86_64-linux-gnu.so : ../../../liblldb.so
--
Path = /home/runner/ndk.zip
Type = zip
Physical Size = 730338259

ERROR: Dangerous symbolic link path was ignored : android-ndk-r27-canary/toolchains/llvm/prebuilt/linux-x86_64/lib/python3.10/site-packages/lldb/lldb-argdumper : ../../../../bin/lldb-argdumper

Sub items Errors: 2

Archives with Errors: 1

Sub items Errors: 2
```

If you'd rather make a separate repo for this, please disregard this PR.